### PR TITLE
Fix python_version format

### DIFF
--- a/malshare.json
+++ b/malshare.json
@@ -15,10 +15,7 @@
     "package_name": "phantom_malshare",
     "main_module": "malshare_connector.py",
     "min_phantom_version": "5.1.0",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "Cloud, tested on 15th September, 2021"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)